### PR TITLE
Add Jenkinsfile for Jenkins integration for python-calculator

### DIFF
--- a/python-calculator/Jenkinsfile
+++ b/python-calculator/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any 
+    stages {
+        stage('Run Unit Tests') {
+            steps {
+                sh 'python3 unittest calculator_unittest.py'
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Add initial `Jenkinsfile` file to integrate hosted-Jenkins file with my Github repository. This is for testing I am doing to ensure that my `python-calculator` can have unit-tests ran every time I push a change.

The long-term goal is that I will begin following this CI/CD approach to work I have and I can perhaps even branch this over to my `Misc-Bash-Scripts` once I begin unit testing over there.